### PR TITLE
BUG: Lifecycle code sample contains unexpected ":"

### DIFF
--- a/explainer/index.html
+++ b/explainer/index.html
@@ -193,7 +193,7 @@ var TickTockClock = document.registerElement('tick-tock-clock', {prototype: p});
 &lt;/template&gt;
 &lt;script&gt;
 var p = Object.create(HTMLElement.prototype);
-p.createdCallback: function() {
+p.createdCallback = function() {
     this._root = this.createShadowRoot();
     var template = document.querySelector('#tick-tock-clock-template');
     this._root.appendChild(document.importNode(template.content));


### PR DESCRIPTION
It looks like this sample was converted from using object literal notation to use function expressions, but one of the ":" was missed. I've replaced it with an assignment so that the sample works again.
