### PR TITLE
Removed reference to bug marked as fixed.

### DIFF
--- a/spec/imports/index.html
+++ b/spec/imports/index.html
@@ -134,7 +134,7 @@
 
 <div class="fixme">
 Imported documents share its <code>defaultView</code> with the master document.
-(See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=23170">Bug 23170</a> and <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=22305">Bug 22305</a>.)
+(See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=23170">Bug 23170</a>.)
 </div>
 
 <p>The <a href="http://dom.spec.whatwg.org/#concept-document-url">URL</a> of an <a href="#dfn-import">import</a> is called the <dfn id="dfn-import-location">import location</dfn><!--, and the <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/origin-0.html#origin">origin</a> of the <a href="#dfn-import-location">import location</a> is called <dfn id="dfn-import-origin">import origin</dfn>-->.</p>


### PR DESCRIPTION
Do we still need the reference to bug 23710 (marked "for later")?
