### PR TITLE
Qualify "this specification" with "this version"

### DIFF
--- a/publish/shadow/WD-shadow-dom-20140612/index.html
+++ b/publish/shadow/WD-shadow-dom-20140612/index.html
@@ -489,11 +489,11 @@ table.simple {
 
   <div data-fill-with=warning>
     <details class=annoying-warning open>
-      <summary>This Document Is Obsolete and Has Been Replaced</summary>
+      <summary>This Version of this Document Is Obsolete and Has Been Replaced</summary>
       <p>
-        This specification is obsolete and has been replaced by the document at <a href=http://w3c.github.io/webcomponents/spec/shadow/>http://w3c.github.io/webcomponents/spec/shadow/</a>.
-        Do not attempt to implement this specification.
-        Do not refer to this specification except as a historical artifact.
+        This version of the specification is obsolete and has been replaced by the document at <a href=http://w3c.github.io/webcomponents/spec/shadow/>http://w3c.github.io/webcomponents/spec/shadow/</a>.
+        Do not attempt to implement this version of the specification.
+        Do not refer to this version except as a historical artifact.
       </p>
     </details>
   </div>


### PR DESCRIPTION
As discussed on public-webapps, the text about the spec being obsoleted needs to be qualified with "this version". See http://lists.w3.org/Archives/Public/public-webapps/2014AprJun/0825.html.
