### PR TITLE
Describe focus navigation order for the case with tabindex=-1

### DIFF
--- a/spec/shadow/index.html
+++ b/spec/shadow/index.html
@@ -1007,6 +1007,7 @@
             <ol>
               <li>Let <var>HOST</var> be the <a>shadow host</a> which <a>hosts</a> A</li>
               <li>Let <var>B</var> be the <a>node tree</a> which <var>HOST</var> participates in</li>
+              <li>If <var>HOST</var> explicitly does not participate in the navigation order, specified by <code>tabindex=-1</code>, <var>A</var> does not participate in the navigation order either.</li>
               <li>The <a>navigation order</a> for A <strong>must</strong> be inserted into the <a>navigation order</a> for <var>B</var>:
                 <ol>
                   <li>immediately after <var>HOST</var>, if <var>HOST</var> is <a>focusable</a>; or</li>
@@ -1017,6 +1018,7 @@
             <ol>
               <li>Let <var>B</var> be the <a>younger shadow tree</a> relative to <var>A</var></li>
               <li>Let <var>SHADOW</var> be the <a>shadow insertion point</a> in <var>B</var></li>
+              <li>If <var>SHADOW</var> exists, but it explicitly does not participate in the navigation order, specified by <code>tabindex=-1</code>, <var>A</var> does not participate in the navigation order either.</li>
               <li>If <var>SHADOW</var> exists, the <a>navigation order</a> for <var>A</var> <strong>must</strong> be inserted into the <a>navigation order</a> for <var>B</var> immediately after <var>SHADOW</var> as if <var>SHADOW</var> were assigned the value of <a title="nav-index auto"><code>auto</code></a> for determining its position.</li>
             </ol></li>
         </ol>


### PR DESCRIPTION
This is a proposed draft of shadow navigation order when shadow host or <shadow> with
tabindex=-1, corresponds to https://www.w3.org/Bugs/Public/show_bug.cgi?id=27965 .
