### PR TITLE
Add "http:" to the respec URL so that respec runs when viewing locally

### DIFF
--- a/spec/shadow/index.html
+++ b/spec/shadow/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
   <head>
     <meta charset='utf-8'/>
@@ -6,7 +6,7 @@
     <script src='./autolink-config.js' class='remove'></script>
     <script src='../../assets/scripts/autolink.js' class='remove'></script>
     <link rel="stylesheet" href="../../assets/styles/respec-complement.css" type="text/css" />
-    <script src='//www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+    <script src='http://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
           specStatus: "ED",


### PR DESCRIPTION
This patch allows re-spec to run locally, which is helpful when editing.
If this was intentional for some reasons, I can keep this locally, but wanted to ask if so.
Note that the [ReSpec template](http://www.w3.org/respec/examples/template.html) does have "http:".
