### PR TITLE
Fix typo and add missing selectors

### DIFF
--- a/spec/shadow/index.html
+++ b/spec/shadow/index.html
@@ -254,13 +254,14 @@
         <div class="note">
           <p>
             The editor's draft of CSS Scoping specification [[css-scoping-1]] defines the selectors which are related to Shadow DOM.
-            For those who would search this Shadow DOM specifaction with the name of these selectors, mentioning these selectores here:
+            Specifically, it defines the following selectors related to Shadow DOM:
           </p>
 
           <ul>
-            <li><code>:shadow</code> pseudo element</li>
+            <li><code>::shadow</code> pseudo element</li>
             <li><code>/deep/</code> combinator,  which was replaced with a <code>>>></code> combinator (or <strong>shadow piercing descendant combinator</strong>)</li>
             <li><code>::content</code> pseudo-element</li>
+            <li><code>:host</code> pseudo-class and <code>:host()</code> functional pseudo-class</li>
             <li><code>:host-context()</code> functional pseudo-class</li>
           </ul>
         </div>


### PR DESCRIPTION
There were a couple of typos in here (specifaction, selectores, :shadow), and I couldn't quite understand the second sentence in the note, so I took a stab at rephrasing. Also, I think :host and :host() should be mentioned here.

I realize this section will be changing, so feel free to disregard this PR if it's not useful.
