### PR TITLE
Fix typo in "2.1.1" for attributeChangedCallback

### DIFF
--- a/spec/custom/index.html
+++ b/spec/custom/index.html
@@ -149,7 +149,7 @@ class FlagIcon extends HTMLElement {
 
   static get observedAttributes() { return ["country"]; }
 
-  attributeChangedCallback(name, newValue) {
+  attributeChangedCallback(name, oldValue, newValue) {
     // name will always be "country" due to observedAttributes
     this._countryCode = newValue
     this._updateRendering()


### PR DESCRIPTION
The example given at "2.1.1 Creating a custom tag" shows how to use

attributeChangedCallback(name, newValue)

but "4.2 DOM+: Mutation algorithms" last paragraph states that
this function has 3 arguments (name, oldAttrValue, newAttrValue)
so, newValue given in the example doesn't reflect the meaning of
oldAttrValue
