### PR TITLE
Fix typo

### DIFF
--- a/spec/custom/index.html
+++ b/spec/custom/index.html
@@ -324,7 +324,7 @@ console.log(plasticButton2.getAttribute("is")); // will output "plastic-button"<
 <ul>
     <li>a <dfn id="dfn-element-definition-name" for="custom element definition">name</dfn>, which is a <a>valid custom element name</a>;</li>
     <li>a <dfn id="dfn-element-definition-local-name" for="custom element definition">local name</dfn>, which is a <a href="https://dom.spec.whatwg.org/#concept-element-local-name">local name</a>;</li>
-    <li>a <dfn id="dfn-element-definition-constructor" for="custom element definition">konstructor</dfn>, which is a <a>custom element constructor</a>;</li> <!-- https://github.com/w3c/respec/issues/582 for why it's k -->
+    <li>a <dfn id="dfn-element-definition-constructor" for="custom element definition">constructor</dfn>, which is a <a>custom element constructor</a>;</li> <!-- https://github.com/w3c/respec/issues/582 for why it's k -->
     <li>a <dfn id="dfn-element-definition-prototype" for="custom element definition">prototype</dfn>, which is a JavaScript object;</li>
     <li>a list of <dfn id="dfn-element-definition-observed-attributes">observed attributes</dfn>, which is a <code>sequence&lt;DOMString></code>; </li>
     <li>a collection of <dfn id="dfn-element-definition-lifecycle-callbacks" dfn-for="custom element definition">lifecycle callbacks</dfn>, which is a <a>collection of lifecycle callbacks</a>; and </li>
@@ -379,7 +379,7 @@ dictionary ElementRegistrationOptions {
 
     <li>If this <code>CustomElementsRegistry</code> contains an entry with <a href="#dfn-element-definition-name">name</a> <var>name</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>NotSupportedError</code> and abort these steps.</li>
 
-    <li>If this <code>CustomElementsRegistry</code> contains an entry with <a href="#dfn-element-definition-constructor">contructor</a> <var>constructor</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>NotSupportedError</code> and abort these steps.</li>
+    <li>If this <code>CustomElementsRegistry</code> contains an entry with <a href="#dfn-element-definition-constructor">constructor</a> <var>constructor</var>, <a href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>NotSupportedError</code> and abort these steps.</li>
 
     <li>Let <var>localName</var> be <var>name</var>.</li>
 

--- a/spec/custom/index.html
+++ b/spec/custom/index.html
@@ -324,7 +324,7 @@ console.log(plasticButton2.getAttribute("is")); // will output "plastic-button"<
 <ul>
     <li>a <dfn id="dfn-element-definition-name" for="custom element definition">name</dfn>, which is a <a>valid custom element name</a>;</li>
     <li>a <dfn id="dfn-element-definition-local-name" for="custom element definition">local name</dfn>, which is a <a href="https://dom.spec.whatwg.org/#concept-element-local-name">local name</a>;</li>
-    <li>a <dfn id="dfn-element-definition-constructor" for="custom element definition">constructor</dfn>, which is a <a>custom element constructor</a>;</li> <!-- https://github.com/w3c/respec/issues/582 for why it's k -->
+    <li>a <dfn id="dfn-element-definition-constructor" for="custom element definition">constructor</dfn>, which is a <a>custom element constructor</a>;</li>
     <li>a <dfn id="dfn-element-definition-prototype" for="custom element definition">prototype</dfn>, which is a JavaScript object;</li>
     <li>a list of <dfn id="dfn-element-definition-observed-attributes">observed attributes</dfn>, which is a <code>sequence&lt;DOMString></code>; </li>
     <li>a collection of <dfn id="dfn-element-definition-lifecycle-callbacks" dfn-for="custom element definition">lifecycle callbacks</dfn>, which is a <a>collection of lifecycle callbacks</a>; and </li>


### PR DESCRIPTION
1) Every konstructor's reference points to a "constructor"
2) Typo at the steps for define(name, constructor, options)
