### PR TITLE
Remove the reference attachedCallback in example

### DIFF
--- a/spec/custom/index.html
+++ b/spec/custom/index.html
@@ -288,7 +288,7 @@ class TacoButton extends HTMLElement {
     });
   }
 
-  attachedCallback() {
+  connectedCallback() {
     this.setAttribute("role", "button");
     this.setAttribute("tabindex", "0");
 


### PR DESCRIPTION
attachedCallback() is mentionend in the example TacoButton but
at the interface 2.4 CustomElementsRegistry the connectedCallback
replaces the attachedCallback.
