### PR TITLE
[minor] typo in interface name

### DIFF
--- a/spec/custom/index.html
+++ b/spec/custom/index.html
@@ -1497,7 +1497,7 @@ console.assert(image.height === 200);
       <p>HTML's <code>Window</code> object definition must be extended as follows:</p>
       <pre class="idl">
 partial interface Window {
-    readonly attribute CustomElementsRegistry customElements;
+    readonly attribute CustomElementRegistry customElements;
 };
 </pre>
     </section>


### PR DESCRIPTION
The interface is defined as CustomElementRegistry not CustomElementsRegistry; looks like a typo.
