### PR TITLE
Add [SameObject] to import IDL attribute

### DIFF
--- a/spec/imports/index.html
+++ b/spec/imports/index.html
@@ -194,7 +194,7 @@ In <a href='#fig-import-list'></a>,
 
 <pre class="idl">
 partial interface HTMLLinkElement {
-    readonly attribute Document? import;
+    [SameObject] readonly attribute Document? import;
 };
 </pre>
 
@@ -204,8 +204,6 @@ partial interface HTMLLinkElement {
     <li>the <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element is not <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-a-document">in a <code>Document</code></a></li>
 </ul>
 <p>Otherwise, the attribute MUST return the <a>imported document</a> for the <a>import</a>, represented by the <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element.</p>
-
-<p>The same object MUST be returned each time.</p>
 
 <aside class="example" id='import-dom-access'>
 <p>Here's how one could access the imported document, mentioned in <a href='#hearts-example'>previous example</a>:</p>


### PR DESCRIPTION
Oops, this was too rush. According to WebIDL spec, `[SameObject]` does not work with nullables. Sorry for the notification.