### PR TITLE
fix example so that attachShadow does not throw an exception

### DIFF
--- a/spec/shadow/index.html
+++ b/spec/shadow/index.html
@@ -1044,14 +1044,14 @@ object’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a da
 
       <p>Bob was asked to turn a simple list of links into a News Widget, which has links organized into two categories: breaking news and just news. The current document markup for the stories looks like this:</p>
       <pre class="example highlight">
-&lt;ul class="stories"&gt;
+&lt;div class="stories"&gt;
     &lt;li&gt;&lt;a href="//example.com/stories/1"&gt;A story&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="//example.com/stories/2"&gt;Another story&lt;/a&gt;&lt;/li&gt;
     &lt;li class="breaking" slot="breaking"&gt;&lt;a href="//example.com/stories/3"&gt;Also a story&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="//example.com/stories/4"&gt;Yet another story&lt;/a&gt;&lt;/li&gt;
     &lt;li&gt;&lt;a href="//example.com/stories/5"&gt;Awesome story&lt;/a&gt;&lt;/li&gt;
     &lt;li class="breaking" slot="breaking"&gt;&lt;a href="//example.com/stories/6"&gt;Horrible story&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
+&lt;/div&gt;
       </pre>
 
       <p class="issue">
@@ -1113,7 +1113,7 @@ function makeShadowTree(storyList)
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('ul.stories').forEach(makeShadowTree);
+    document.querySelectorAll('div.stories').forEach(makeShadowTree);
 });
       </pre>
 


### PR DESCRIPTION
An unordered list `<ul>` is one of the elements that does not allow `attachShadow()` to be called. The example tries to call `attachShadow()` on the `<ul>`. This commit fixes this problem.