### PR TITLE
Fix an arguments order of replaceChild

### DIFF
--- a/proposals/Template-Instantiation.md
+++ b/proposals/Template-Instantiation.md
@@ -322,7 +322,7 @@ document.defineTemplateType("with-for-each", { processCallback: function (instan
     for (const template of instance.querySelectorAll("template")) {
         ...
         if (template.directive == "foreach")
-            template.parentNode.replaceChild(template, template.createInstance(state[template.expression]));
+            template.parentNode.replaceChild(template.createInstance(state[template.expression]), template);
     }
 }});
 ```


### PR DESCRIPTION
> replacedNode = parentNode.replaceChild(newChild, oldChild);

* https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild