### PR TITLE
Fix HTML Modules demo links

### DIFF
--- a/proposals/HTML-Modules-Demo/HTML5-Element.html
+++ b/proposals/HTML-Modules-Demo/HTML5-Element.html
@@ -1,0 +1,43 @@
+<template id="html5ElementTemplate">
+  <style>
+      .outerDiv {
+          border:0.1em solid blue;
+          display:inline-block;
+          padding: 0.4em;
+      }
+
+      .devText {
+          font-weight: bold;
+          font-size: 1.4em;
+          text-align: center;
+          margin-top: 0.3em;
+      }
+
+      .mainImage {
+          height:254px;
+      }
+  </style>
+  <div class="outerDiv">
+      <img class="mainImage" src="https://www.w3.org/html/logo/downloads/HTML5_Logo_512.png" />
+      <div class="devText">HTML Modules Are Great!</div>
+  </div>
+</template>
+<script type="module">
+  let moduleDocument = import.meta.document;
+
+  class HTML5Element extends HTMLElement {
+      constructor() {
+          super();
+          console.log("HTML5Element constructor");
+          let shadowRoot = this.attachShadow({ mode: "closed" });
+          let template = moduleDocument.getElementById("html5ElementTemplate");
+          shadowRoot.appendChild(document.importNode(template.content, true));
+      }
+
+      connectedCallback() {
+          console.log("HTML5Element connectedCallback");
+      }
+  }
+
+  export { HTML5Element };
+</script>

--- a/proposals/HTML-Modules-Demo/Main.html
+++ b/proposals/HTML-Modules-Demo/Main.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+    <head>
+        <title>HTML Modules Demo</title>
+        <script type="module">
+            import { HTML5Element } from "./html5Element.html";
+            window.customElements.define("my-html5-element", HTML5Element);
+        </script>
+    </head>
+    <body>
+        <my-html5-element></my-html5-element>
+    </body>
+</html>

--- a/proposals/html-modules-explainer.md
+++ b/proposals/html-modules-explainer.md
@@ -118,11 +118,11 @@ let theTemplate = importedDoc.querySelector("template");
 
 The following example demonstrates how a custom element definition could be packaged as an HTML Module:
 
-[html5Element.html](demo/html5Element.html)
+[html5Element.html](HTML-Modules-Demo/HTML5-Element.html)
 
 This example demonstrates how the above custom element definition can be consumed:
 
-[main.html](demo/main.html)
+[main.html](HTML-Modules-Demo/Main.html)
 
 ## Major open design questions
 


### PR DESCRIPTION
Add HTML Modules demo.  Fix links in HTML Modules explainer doc referencing the demo.