### PR TITLE
Update reference-target-explainer supported attributes

### DIFF
--- a/proposals/reference-target-explainer.md
+++ b/proposals/reference-target-explainer.md
@@ -136,7 +136,7 @@ This feature is intended to work with **all** attributes that refer to another e
   - `list`
   - `popovertarget`
   - `anchor` (proposed in the [Popover API Explainer](https://open-ui.org/components/popover.research.explainer/#anchoring))
-  - `invoketarget` (proposed in [Invokers Explainer](https://open-ui.org/components/invokers.explainer/))
+  - `commandfor` (proposed in [Invokers Explainer](https://open-ui.org/components/invokers.explainer/))
   - `interesttarget` (proposed in [Invokers Explainer](https://open-ui.org/components/invokers.explainer/))
 - Tables
   - `headers`


### PR DESCRIPTION
Just a small update to replace `invoketarget` with `commandfor` based on the latest invokers proposal.