### PR TITLE
Clarify that declarative custom element definitions don't contain declarative shadow roots.

### DIFF
--- a/proposals/Declarative-Custom-Elements-Strawman.md
+++ b/proposals/Declarative-Custom-Elements-Strawman.md
@@ -9,7 +9,8 @@ First, with the proposed template instantiation API in mind, we imagined a HTML 
 
 ```html
 <definition name="my-element" constructor="MyElement">
-    <template shadowmode="closed">~</template>
+    <shadowoptions mode="open"></shadowoptions>
+    <template>~</template>
     <script>
       class MyElement extends HTMLElement { ~ }
     </script>
@@ -22,7 +23,8 @@ This still requires having to repeat the constructor name twice. We can avoid th
 
 ```html
 <definition name="my-element">
-    <template shadowmode="closed">~</template>
+    <shadowoptions mode="closed"></shadowoptions>
+    <template>~</template>
     <script type="module">
       export default class MyElement extends HTMLElement { ~ }
     </script>
@@ -42,7 +44,8 @@ class /* default custom element */ extends HTMLElement {
         const template = customElements.getTemplate(this);
         if (!template)
             return;
-        #shadowRoot = this.attachShadow({mode: template.getAttribute('shadowmode')});
+        const shadowOptions = customElements.getShadowOptions(this);
+        #shadowRoot = this.attachShadow(shadowOptions);
         #templateInstance = #shadowRoot.appendChild(template.createInstance(#shadowRoot));
     }
     attributeChangedCallback(attributeName, oldValue, newValue, namespace) {
@@ -57,7 +60,8 @@ Note that the shadow root of the custom element is passed to createInstance's st
 
 ```html
 <definition name="percentage-bar">
-    <template shadowmode="closed">
+    <shadowoptions mode="closed"></shadowoptions>
+    <template>
         <div id="progressbar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{root.attributes.percentage.value}}">
             <div id="bar" style="width: {{root.attributes.percentage.value}}%"></div>
             <div id="label"><slot></slot></div>


### PR DESCRIPTION
The current Declarative Custom Elements Strawman was authored before Declarative Custom Elements was specified, and the pattern of putting shadow root instance options on the `<template>` element. Now that that pattern does exist, it has created something of an semantic ambiguity with the strawman syntax. (with the assumption that `shadowmode` should be updated to `shadowrootmode`).

In this example, is `<template shadowmode="open">` intended to do?

```html
<definition name="my-element" constructor="MyElement">
    <template shadowmode="open">~</template>
</definition>
```

Does it:
1. Create a shadow root on the `<definition>` element
2. Define a template with options to be used to initialize instance shadow roots.

If the answer is (2), then we have the same syntax with two different behaviors: one creates a shadow root instance, one defines future shadow roots.

Since the strawman was created before DSD, it doesn't seem like this collision was intended. I think to separate DSD from declarative custom elements, even just in this strawman syntax, we should make a small edit to put the options on a new element. This has the benefit of shortening the option names by not requiring the `shadowroot` prefix on every one.

```html
<definition name="my-element" constructor="MyElement">
    <shadowoptions mode="open"></shadowoptions>
    <template>~</template>
</definition>
```

cc @rniwa 