### PR TITLE
Fix HTML Modules inline module script

### DIFF
--- a/proposals/html-modules-proposal.md
+++ b/proposals/html-modules-proposal.md
@@ -181,7 +181,7 @@ Example:
 > <div id="blogPost">
 > 	<p> Some Amazing Content </p>
 > </div>
-> <script>
+> <script type="module">
 > 	let blogPost = import.meta.document.querySelector("#blogPost");
 > 	export {blogPost}
 > </script>


### PR DESCRIPTION
According to the proposal, HTML Modules can only run inline module scripts. This PR fixes an example that appears to accidentally violate this requirement.

/cc @dandclark 